### PR TITLE
Fix resourceTypes Methods Incorrectly Merging

### DIFF
--- a/lib/raml_parser/model.rb
+++ b/lib/raml_parser/model.rb
@@ -44,6 +44,10 @@ module RamlParser
         resource.base_uri_parameters = a.base_uri_parameters.merge(b.base_uri_parameters)
         resource.uri_parameters = a.uri_parameters.merge(b.uri_parameters)
         resource.methods = a.methods.merge(b.methods)
+        resource.methods.keys.each do |meth|
+          next if a.methods[meth].nil?
+          resource.methods[meth] = Method.merge(a.methods[meth], resource.methods[meth])
+        end
         resource.type = a.type.merge(b.type)
         resource.is = a.is.merge(b.is)
         resource.secured_by = (a.secured_by + b.secured_by).uniq

--- a/lib/raml_parser/version.rb
+++ b/lib/raml_parser/version.rb
@@ -1,3 +1,3 @@
 module RamlParser
-  VERSION = "0.2.5"
+  VERSION = "0.2.6"
 end

--- a/spec/examples/raml/resourcetypes.raml
+++ b/spec/examples/raml/resourcetypes.raml
@@ -6,6 +6,10 @@ resourceTypes:
   - collection:
       description: A collection
       get:
+        queryParameters:
+          search:
+            description: Filter results by search
+            type: string
         description: Get all items
       post:
         description: Create a new item
@@ -14,3 +18,8 @@ resourceTypes:
   put:
   post:
     description: Overriden
+  get:
+    queryParameters:
+      size:
+        description: Filter results by size
+        type: string

--- a/spec/lib/raml_parser_spec.rb
+++ b/spec/lib/raml_parser_spec.rb
@@ -174,6 +174,7 @@ RSpec.describe RamlParser::Parser do
 
   it 'mixes in resource types' do
     raml = RamlParser::Parser.parse_file('spec/examples/raml/resourcetypes.raml')
+    expect(raml.resources[0].methods['get'].query_parameters.keys).to eq %w(search size)
     expect(raml.resources[0].methods.keys).to eq ['get', 'post', 'put']
     expect(raml.resources[0].methods['get'].description).to eq 'Get all items'
     expect(raml.resources[0].methods['post'].description).to eq 'Overriden'


### PR DESCRIPTION
With a given `resourceType` the methods where not properly being
merged together.  For instance, a resource declares to be of type
`foo`, and that type defines under it's `get` method two query
parameters of `bar` and `baz`.  If the resource itself also wants
to fold in several more query parameters under the `get` method
they will not be folded in, but instead completely override the
entire `get` method described by the resource.

Looking at the following topic under the raml spec:
https://github.com/raml-org/raml-spec/blob/master/raml-0.8.md#applying-resource-types-and-traits

It _appears_ that the the methods should be merged together and
note simply overriden.
